### PR TITLE
configure babel for styled-components SSR setting

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,9 +3,20 @@
 		"razzle/babel"
 	],
 	"plugins": [
-		["babel-plugin-root-import", {
-			"rootPathSuffix": "src/",
-			"rootPathPrefix": "@"
-		}]
+		[
+			"babel-plugin-root-import",
+			{
+				"rootPathSuffix": "src/",
+				"rootPathPrefix": "@"
+			}
+		],
+		[
+			"styled-components",
+			{
+				"ssr": true,
+				"displayName": true,
+				"preprocess": false
+			}
+		]
 	]
 }


### PR DESCRIPTION
This configuration necessary to fix "Warning: Prop `className` did not match." errors.
